### PR TITLE
search with specific baseDN

### DIFF
--- a/lib/components/search.js
+++ b/lib/components/search.js
@@ -326,7 +326,7 @@ function search(baseDN, opts, callback) { // jshint -W071
     options.callback = baseDN;
     options.opts = {};
   } else if (typeof baseDN === 'object') {
-    options.baseDN = ad.baseDN;
+    options.baseDN = baseDN.baseDN || ad.baseDN;
     options.callback = opts;
     options.opts = baseDN;
   } else if (typeof baseDN === 'string') {


### PR DESCRIPTION
Hi @jsumners,
 
In the original activedirectory by gheeres it was possible to specify baseDN on function findUsers, for example 

     ad.findUsers( {baseDN: 'OU=eastcoast,DC=company,DC=com'}, function(err, users) .......

In activedirectory2, this option was missing, it would only use the baseDN that was specified at new ActiveDirectrory(options).
This commit fixes that: if the search option specifies a baseDN then it is used, else it defaults to ad.baseDN.