### PR TITLE
fetch more than 1000 users

### DIFF
--- a/lib/components/search.js
+++ b/lib/components/search.js
@@ -66,7 +66,7 @@ function Searcher(opts) { // jshint -W071
   this.controls = this.opts.controls || [];
   
   if (this.opts.opts.paged === undefined) {
-    this.opts.opts.paged=true;
+    this.opts.opts.paged = true;
   }
 
   if (this.opts.includeDeleted) {

--- a/lib/components/search.js
+++ b/lib/components/search.js
@@ -65,25 +65,9 @@ function Searcher(opts) { // jshint -W071
 
   this.controls = this.opts.controls || [];
   
-  if (this.opts.opts.paged===undefined) {
+  if (this.opts.opts.paged === undefined) {
     this.opts.opts.paged=true;
   }
-  /*
-  // Add paging results control by default if not already added.
-  const pagedControls = this.controls.filter(
-    (control) => control instanceof ldap.PagedResultsControl
-  );
-  if (pagedControls.length === 0) {
-    log.trace('Adding PagedResultControl to search (%s) with filter "%s" for %j',
-              this.baseDN,
-              this.query.filter,
-              (this.query.attributes) ? this.opts.attributes : '[*]'
-    );
-    this.controls.push(new ldap.PagedResultsControl({
-      value: { size: ad.pageSize }
-    }));
-  }
-  */
 
   if (this.opts.includeDeleted) {
     const deletedControls = this.controls.filter(

--- a/lib/components/search.js
+++ b/lib/components/search.js
@@ -64,7 +64,11 @@ function Searcher(opts) { // jshint -W071
   });
 
   this.controls = this.opts.controls || [];
-
+  
+  if (this.opts.opts.paged===undefined) {
+    this.opts.opts.paged=true;
+  }
+  /*
   // Add paging results control by default if not already added.
   const pagedControls = this.controls.filter(
     (control) => control instanceof ldap.PagedResultsControl
@@ -79,6 +83,7 @@ function Searcher(opts) { // jshint -W071
       value: { size: ad.pageSize }
     }));
   }
+  */
 
   if (this.opts.includeDeleted) {
     const deletedControls = this.controls.filter(


### PR DESCRIPTION
Hi James,
I was very surprised to notice that I could not get more than 1000 users from our test AD-server, paging just does not seem to work. Very surprising because you have spent so much work in your fork to do just that. I have made a simple fix in search.js , it works for us. But I am worried about this simple fix because I do not understand why your original activedirectory2 works for you and not for our AD server. I hope you can comment?

Fix that findUsers or getUsersForGroup never fetch more than 1000 users. Adding option paged=true would raise error "redundant pagedResultControl". 
Instead of programmatically adding a new PagedResultsControl, simply set opts.paged=true and let ldapjs handle it.

Thanks, Jurjen.