### PR TITLE
fix PagedError: missing paged control in mocha

### DIFF
--- a/lib/components/search.js
+++ b/lib/components/search.js
@@ -133,6 +133,9 @@ Searcher.prototype.search = function search() {
       this.searchComplete = true;
       this.onSearchEnd(err);
     });
+    res.on('pageError', (err) => {
+      this.searchComplete = true;
+    });
   });
 };
 


### PR DESCRIPTION
I think this fixes issue https://github.com/jsumners/node-activedirectory/issues/3

mochatest for activedirectory2 failed because the mockServer does not truly support paging, causing ldapjs/lib/client/search_pager.js to throw a PagedError. This PagedError is now handled in search.js by subscribing to 'pageError'.