### PR TITLE
pass tlsOptions from ad.opts to ldap

### DIFF
--- a/lib/components/utilities.js
+++ b/lib/components/utilities.js
@@ -21,7 +21,7 @@ function createClient (url, opts, ad) {
     throw new Error('No url specified for ActiveDirectory client.')
   }
 
-  const ldapOpts = getLdapClientOpts(Object.assign({ url: _url }, opts))
+  const ldapOpts = getLdapClientOpts(Object.assign({ url: _url }, ad.opts, opts))
   return ldap.createClient(ldapOpts)
 }
 


### PR DESCRIPTION
tlsOptions (and selected other attributes) are copied from ad.options to ldap.options.