### PR TITLE
Handle connection timeout event

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -913,6 +913,10 @@ ActiveDirectory.prototype.authenticate = function authenticate (username, passwo
   }
 
   const client = utils.createClient(null, null, this)
+  client.on('connectTimeout', (err) => {
+    this.emit('error', err)
+    return callback(err, false)
+  })
   client.on('error', (err) => {
     // only used on socket connection failure since it doesn't invoke bind cb
     this.emit('error', err)
@@ -966,6 +970,10 @@ ActiveDirectory.prototype.getRootDSE = function getRootDSE (url, attributes, cal
   log.trace('getRootDSE(%s,%j)', _url, _attributes)
 
   const client = utils.createClient.call(this, _url, this)
+  client.on('connectTimeout', (err) => {
+    this.emit('error', err)
+    _cb(err)
+  })
   client.on('error', (err) => {
     // only needed for bind errors
     if (err.errno !== 'ECONNRESET') { // we don't care about ECONNRESET

--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -970,10 +970,6 @@ ActiveDirectory.prototype.getRootDSE = function getRootDSE (url, attributes, cal
   log.trace('getRootDSE(%s,%j)', _url, _attributes)
 
   const client = utils.createClient.call(this, _url, this)
-  client.on('connectTimeout', (err) => {
-    this.emit('error', err)
-    _cb(err)
-  })
   client.on('error', (err) => {
     // only needed for bind errors
     if (err.errno !== 'ECONNRESET') { // we don't care about ECONNRESET

--- a/lib/components/search.js
+++ b/lib/components/search.js
@@ -58,6 +58,10 @@ function Searcher (opts) {
   this.rangeProcessing = false
 
   this.client = utils.createClient(ad.url || ad.opts.url, this.ldapOpts, ad)
+  this.client.on('connectTimeout', (err) => {
+    // to handle connection errors
+    this.callback(err)
+  })
   this.client.on('error', (err) => {
     // to handle connection errors
     this.callback(err)

--- a/test/find.js
+++ b/test/find.js
@@ -3,6 +3,7 @@
 /* eslint-disable no-unused-expressions */
 
 const expect = require('chai').expect
+const ldapjs = require('ldapjs')
 const ActiveDirectory = require('../index')
 const config = require('./config')
 
@@ -212,6 +213,17 @@ describe('find Method', function () {
           })
         })
 
+        done()
+      })
+    })
+
+    it('should return err (ConnectionError) when connection timeouts', function (done) {
+      new ActiveDirectory({
+        url: 'ldap://google.com',
+        connectTimeout: 100
+      }).find({}, function (err, result) {
+        expect(err).to.be.an.instanceOf(ldapjs.ConnectionError)
+        expect(result).to.be.undefined
         done()
       })
     })

--- a/test/find.js
+++ b/test/find.js
@@ -219,7 +219,7 @@ describe('find Method', function () {
 
     it('should return err (ConnectionError) when connection timeouts', function (done) {
       new ActiveDirectory({
-        url: 'ldap://google.com',
+        url: 'ldap://example.com',
         connectTimeout: 100
       }).find({}, function (err, result) {
         expect(err).to.be.an.instanceOf(ldapjs.ConnectionError)

--- a/test/network.js
+++ b/test/network.js
@@ -37,7 +37,7 @@ describe('Network Connections', function () {
 
     it('should return err (ConnectionError) when connection timeouts', function (done) {
       const ad = new ActiveDirectory({
-        url: 'ldap://google.com',
+        url: 'ldap://example.com',
         connectTimeout: 1
       })
       ad.authenticate(username, password, function (err, auth) {

--- a/test/network.js
+++ b/test/network.js
@@ -3,6 +3,7 @@
 /* eslint-disable no-unused-expressions */
 
 const expect = require('chai').expect
+const ldapjs = require('ldapjs')
 const ActiveDirectory = require('../index')
 
 describe('Network Connections', function () {
@@ -29,6 +30,18 @@ describe('Network Connections', function () {
       ad.authenticate(username, password, function (err, auth) {
         expect(err).to.be.an.instanceof(Error)
         expect(err.code).to.equal('ECONNREFUSED')
+        expect(auth).to.be.false
+        done()
+      })
+    })
+
+    it('should return err (ConnectionError) when connection timeouts', function (done) {
+      const ad = new ActiveDirectory({
+        url: 'ldap://google.com',
+        connectTimeout: 1
+      })
+      ad.authenticate(username, password, function (err, auth) {
+        expect(err).to.be.an.instanceOf(ldapjs.ConnectionError)
         expect(auth).to.be.false
         done()
       })


### PR DESCRIPTION
When setting ldapjs connectTimeout option then ldapjs emits connectTimeout event (https://github.com/mcavage/node-ldapjs/blob/master/lib/client/client.js#L1226), that is not listened on the node-activedirectory side, therefor never catched. Added event listers for this event.