### PR TITLE
Escape asterisk characters in group names

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -606,7 +606,7 @@ ActiveDirectory.prototype.isUserMemberOf = function isUserMemberOf (opts, userna
   }
   log.trace('isUserMemberOf(%j,%s,%s)', _opts, _username, _groupName)
 
-  _opts.attributes = ['cn', 'cn']
+  _opts.attributes = ['cn', 'dn']
   this.getGroupMembershipForUser(_opts, _username, function (err, groups) {
     if (err) {
       return _cb(err)
@@ -618,13 +618,8 @@ ActiveDirectory.prototype.isUserMemberOf = function isUserMemberOf (opts, userna
 
     // Check to see if the group.distinguishedName or group.cn matches the list of
     // retrieved groups.
-    const lowerCaseGroupName = _groupName.toLowerCase().replace(/\s/g, '')
-    const result = groups.filter((g) => {
-      const dn = (g.dn || '').toLowerCase().replace(/\s/g, '').replace(/\*/g, '\\*')
-      const cn = (g.cn || '').toLowerCase().replace(/\s/g, '').replace(/\*/g, '\\*')
-      const cnregex = new RegExp(`^(cn=)?${cn}`)
-      return dn === lowerCaseGroupName || cnregex.test(lowerCaseGroupName)
-    }).length > 0
+    const lowerCaseGroupName = _groupName.toLowerCase()
+    const result = groups.filter((g) => g.dn.toLowerCase() === lowerCaseGroupName || g.cn.toLowerCase().includes(lowerCaseGroupName)).length > 0
     log.trace('"%s" %s a member of "%s"', _username, result ? 'IS' : 'IS NOT', _groupName)
     _cb(null, result)
   })

--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -620,8 +620,8 @@ ActiveDirectory.prototype.isUserMemberOf = function isUserMemberOf (opts, userna
     // retrieved groups.
     const lowerCaseGroupName = _groupName.toLowerCase().replace(/\s/g, '')
     const result = groups.filter((g) => {
-      const dn = (g.dn || '').toLowerCase().replace(/\s/g, '')
-      const cn = (g.cn || '').toLowerCase().replace(/\s/g, '')
+      const dn = (g.dn || '').toLowerCase().replace(/\s/g, '').replace(/\*/g, '\\*')
+      const cn = (g.cn || '').toLowerCase().replace(/\s/g, '').replace(/\*/g, '\\*')
       const cnregex = new RegExp(`^(cn=)?${cn}`)
       return dn === lowerCaseGroupName || cnregex.test(lowerCaseGroupName)
     }).length > 0

--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -618,8 +618,8 @@ ActiveDirectory.prototype.isUserMemberOf = function isUserMemberOf (opts, userna
 
     // Check to see if the group.distinguishedName or group.cn matches the list of
     // retrieved groups.
-    const lowerCaseGroupName = _groupName.toLowerCase()
-    const result = groups.filter((g) => g.dn.toLowerCase() === lowerCaseGroupName || g.cn.toLowerCase().includes(lowerCaseGroupName)).length > 0
+    const lowerCaseGroupName = _groupName.toLowerCase().replace(/\s/g, '')
+    const result = groups.filter((g) => g.dn.toLowerCase().replace(/\s/g, '') === lowerCaseGroupName || g.cn.toLowerCase().replace(/\s/g, '').includes(lowerCaseGroupName)).length > 0
     log.trace('"%s" %s a member of "%s"', _username, result ? 'IS' : 'IS NOT', _groupName)
     _cb(null, result)
   })


### PR DESCRIPTION
In our organization's Active Directory instance, we have group names with asterisks in them (so they show up at the top of the group listing). The function `isUserMemberOf` uses regex to test if  common and distinguished names are valid, which is fine until an asterisk is in the name. It causes an exception because of the unescaped `*` in the regex. This adds a second replace statement that escapes it so when it's used in the RegExp statement, it still evaluates correctly. This fix worked fine for me but if you have a better way to go about it, I'm fine with it as long as it works.