### PR TITLE
Added handling of AD/LDAP error codes 52e and 775

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -948,6 +948,27 @@ ActiveDirectory.prototype.authenticate = function authenticate (username, passwo
     if (err) {
       log.trace('%s. Error: %s', message, err)
       this.emit('error', err)
+
+      // Retrieve the AD error code
+      const adErrCode = err.lde_message.match(/data ([0-9]+[a-z]|[0-9]+)/)
+
+      // Check for known error codes
+      if(adErrCode[1] == '52e') {
+        err = {
+          code: '52e',
+          errno: 'AD_INVALID_CREDENTIALS',
+          description: 'The supplied credential is invalid'
+        }
+      }
+
+      if(adErrCode[1] == 775) {
+        err = {
+          code: '775',
+          errno: 'AD_ACCOUNT_LOCKED',
+          description: 'The supplied credential is locked'
+        }
+      }
+      
       return callback(err, false)
     }
 

--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -953,7 +953,7 @@ ActiveDirectory.prototype.authenticate = function authenticate (username, passwo
       const adErrCode = err.lde_message.match(/data ([0-9]+[a-z]|[0-9]+)/)
 
       // Check for known error codes
-      if(adErrCode[1] == '52e') {
+      if (adErrCode[1] === '52e') {
         err = {
           code: '52e',
           errno: 'AD_INVALID_CREDENTIALS',
@@ -961,14 +961,13 @@ ActiveDirectory.prototype.authenticate = function authenticate (username, passwo
         }
       }
 
-      if(adErrCode[1] == 775) {
+      if (adErrCode[1] === 775) {
         err = {
           code: '775',
           errno: 'AD_ACCOUNT_LOCKED',
           description: 'The supplied credential is locked'
         }
       }
-      
       return callback(err, false)
     }
 


### PR DESCRIPTION
Making the most common AD error codes more "human readable"