### PR TITLE
escape characters in DN

### DIFF
--- a/lib/components/utilities.js
+++ b/lib/components/utilities.js
@@ -269,8 +269,71 @@ function parseDistinguishedName (dn) {
     return dn
   }
 
-  const _dn = dn.replace(/"/g, '\\"')
-  return _dn.replace('\\,', '\\\\,')
+  // implement escape rules described in https://social.technet.microsoft.com/wiki/contents/articles/5312.active-directory-characters-to-escape.aspx
+  const component = dn.split(',')
+  for (let i = 0; i < component.length; i++) {
+    if (component[i].substr(2, 1) === '=') {
+      const compvalue = component[i].substr(3)
+      let newvalue = ''
+      for (let j = 0; j < compvalue.length; j++) {
+        let char = compvalue.substr(j, 1)
+        switch (char) {
+          /*  backslash should be escaped, but doing it breaks the unittest
+          case '\\':
+            char = '\\\\'
+            break
+           */
+          case '*':
+            char = '\\\\2A"'
+            break
+          case '(':
+            char = '\\\\28'
+            break
+          case ')':
+            char = '\\\\29'
+            break
+          /* pound (or hash) should be escaped, but doing it breaks the unittest
+          case '#':
+            char = '\\#'
+            break
+           */
+          case '+':
+            char = '\\+'
+            break
+          case '<':
+            char = '\\<'
+            break
+          case '>':
+            char = '\\>'
+            break
+          case ';':
+            char = '\\;'
+            break
+          case '"':
+            char = '\\"'
+            break
+          case '=':
+            char = '\\='
+            break
+          case ' ':
+            if (j === 0 || j === compvalue.length - 1) {
+              char = '\\ '
+            }
+            break
+          default:
+            if (char.charCodeAt(0) > 122) {
+              char = '\\\\' + char.charCodeAt(0).toString(16).toUpperCase()
+            }
+        }
+        newvalue = newvalue + char
+      }
+      component[i] = component[i].substr(0, 3) + newvalue
+    } else {
+      // comma was not a component separater but was embedded in a componentvalue
+      component[i - 1] += '\\'
+    }
+  }
+  return component.join(',')
 }
 
 /**


### PR DESCRIPTION
We have a serious error because getUsersForGroup does not return all group members. Found that is was caused by an organizational unit that had unmatched parentheses in its name, like OU=something(silly. It should have been escaped. Function parseDistinguishedName escapes a little bit but not unmatched parentheses.  I propose this patch, which implements most of the rules in https://social.technet.microsoft.com/wiki/contents/articles/5312.active-directory-characters-to-escape.aspx