### PR TITLE
revert escaping, remove "snazzy" dep

### DIFF
--- a/lib/components/utilities.js
+++ b/lib/components/utilities.js
@@ -320,10 +320,6 @@ function parseDistinguishedName (dn) {
               char = '\\ '
             }
             break
-          default:
-            if (char.charCodeAt(0) > 122) {
-              char = '\\\\' + char.charCodeAt(0).toString(16).toUpperCase()
-            }
         }
         newvalue = newvalue + char
       }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "abstract-logging": "^1.0.0",
     "async": "^2.5.0",
     "ldapjs": "^1.0.1",
-    "merge-options": "^1.0.0",
-    "snazzy": "^7.0.0"
+    "merge-options": "^1.0.0"
   },
   "scripts": {
     "lint": "standard | snazzy",
@@ -51,6 +50,7 @@
     "mocha": "^3.5.3",
     "pino": "^4.7.2",
     "pre-commit": "^1.2.2",
+    "snazzy": "^7.0.0",
     "standard": "^10.0.3"
   }
 }


### PR DESCRIPTION
1. fix for issue #49:  non-US-ASCII characters (like Cyrillic) were escaped in a wrong way, resulting in a query that did not return groupmembers.  Tests show that the attempt to escape seems unnecessary, so this PR removes it.
2. moved "snazzy" dependency to devDependency as requested in issue #50 
