### PR TITLE
fix(*): return undefined if distinguishedName not found

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -484,7 +484,7 @@ ActiveDirectory.prototype.getGroupMembershipForUser = function getGroupMembershi
 
     if (!dn) {
       log.trace('Could not find a distinguishedName for the specified username: "%s"', _username)
-      return _cb(err, results)
+      return _cb()
     }
     this.getGroupMembershipForDN(_opts, dn, groupDnCallback)
   })

--- a/test/getgroupmembershipforuser.test.js
+++ b/test/getgroupmembershipforuser.test.js
@@ -46,8 +46,7 @@ tap.test('#getGroupMembershipForUser()', t => {
   t.test('should return empty groups if groupName doesn\'t exist', t => {
     t.context.ad.getGroupMembershipForUser('!!!NON-EXISTENT GROUP!!!', function (err, groups) {
       t.error(err)
-      t.type(groups, Array)
-      t.equal(groups.length, 0)
+      t.is(groups, undefined)
       t.end()
     })
   })

--- a/test/getgroupmembershipforuserPromised.test.js
+++ b/test/getgroupmembershipforuserPromised.test.js
@@ -45,8 +45,7 @@ tap.test('#getGroupMembershipForUser()', t => {
   t.test('should return empty groups if groupName doesn\'t exist', t => {
     return t.context.ad.getGroupMembershipForUser('!!!NON-EXISTENT GROUP!!!')
       .then((groups) => {
-        t.type(groups, Array)
-        t.equal(groups.length, 0)
+        t.is(groups, undefined)
       })
       .catch(t.error)
   })


### PR DESCRIPTION
it is impossible to distinguish empty groups from the absence of distinguishedName