### PR TITLE
Fixed group.dn and u.dn to distinguished name - was undefined before

### DIFF
--- a/lib/components/getUsersForGroup.js
+++ b/lib/components/getUsersForGroup.js
@@ -71,7 +71,7 @@ GroupUsersFinder.prototype.forEachIter = function forEachIter (member, acb) {
     // prefer to use member.dn instead member.cn, because cn may not be unique
     ad.getUsersForGroup(this.opts, member.dn, (err, nestedUsers) => {
       if (err) throw err
-      nestedUsers.forEach(u => this.users.set(u.dn, u))
+      nestedUsers.forEach(u => this.users.set(u.distinguishedName, u))
       acb()
     })
   } else {
@@ -152,7 +152,7 @@ GroupUsersFinder.prototype.find = function find () {
       return this.callback(null, group)
     }
 
-    this.opts.recursionstack.push(group.dn)
+    this.opts.recursionstack.push(group.distinguishedName)
     if (!Array.isArray(group.member)) {
       group.member = (group.member) ? [group.member] : []
     }


### PR DESCRIPTION
This is the PR for this issue #84 

I really don't know why this fixes the problem but I saw in the debugger that `group.dn` and `u.dn` was undefined. Took me several hours to find this tiny bug. After I changed it to the correct attribute the found user actually has on the object `distinguishedName` it's working now. I will receive now all the users from my nested groups that have other groups nested inside.

**Edit: since  some checks failed maybe you could guide me into the right direction where I can see what test fails. In the CI view where the log is I just have a huge log where most stuff I find is "ok". Where can I look for the actual tests that failed?**