### PR TITLE
Fix missing default for groupExists

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -549,14 +549,14 @@ ActiveDirectory.prototype.getGroupMembershipForGroup = function getGroupMembersh
  * @param {function} callback The callback to execute when completed.
  */
 ActiveDirectory.prototype.userExists = function userExists (opts, username, callback) {
-  let _opts = opts
+  let _opts = opts || {}
   let _username = username
   let _cb = callback
 
   if (typeof username === 'function') {
     _cb = username
     _username = opts
-    _opts = null
+    _opts = {}
   }
   _opts = merge({}, _opts || {})
   log.trace('userExists(%j,%s)', _opts, _username)
@@ -580,14 +580,14 @@ ActiveDirectory.prototype.userExists = function userExists (opts, username, call
  * @param {function} callback The callback to execute when completed.
  */
 ActiveDirectory.prototype.groupExists = function groupExists (opts, groupName, callback) {
-  let _opts = opts
+  let _opts = opts || {}
   let _groupName = groupName
   let _cb = callback
 
   if (typeof groupName === 'function') {
     _cb = groupName
     _groupName = opts
-    _opts = null
+    _opts = {}
   }
   _opts = merge({}, _opts)
   log.trace('groupExists(%j,%s)', _opts, _groupName)

--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -999,7 +999,6 @@ ActiveDirectory.prototype.getRootDSE = function getRootDSE (url, attributes, cal
     if (err.errno !== 'ECONNRESET') { // we don't care about ECONNRESET
       log.trace('A connection error occured searching for root DSE at %s. Error: %s', _url, err)
       this.emit('error', err)
-      _cb(err)
     }
   })
   // Anonymous bind

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "abstract-logging": "^2.0.0",
     "async": "^3.1.0",
-    "ldapjs": "^2.1.0",
+    "ldapjs": "^2.3.3",
     "merge-options": "^2.0.0"
   },
   "scripts": {

--- a/test/groupexists.test.js
+++ b/test/groupexists.test.js
@@ -22,7 +22,7 @@ tap.afterEach((done, t) => {
 })
 
 tap.test('should return true if the groupName (commonName) exists', t => {
-  t.context.ad.groupExists(settings.sAMAccountName, settings.groupName.cn, function (err, exists) {
+  t.context.ad.groupExists(settings.groupName.cn, function (err, exists) {
     t.error(err)
     t.true(exists)
     t.end()
@@ -30,7 +30,7 @@ tap.test('should return true if the groupName (commonName) exists', t => {
 })
 
 tap.test('should return true if the groupName (distinguishedName) exists', t => {
-  t.context.ad.groupExists(settings.sAMAccountName, settings.groupName.dn, function (err, exists) {
+  t.context.ad.groupExists(settings.groupName.dn, function (err, exists) {
     t.error(err)
     t.true(exists)
     t.end()
@@ -38,7 +38,7 @@ tap.test('should return true if the groupName (distinguishedName) exists', t => 
 })
 
 tap.test('should return false if the groupName doesn\'t exist', t => {
-  t.context.ad.groupExists(settings.sAMAccountName, '!!!NON-EXISTENT GROUP!!!', function (err, exists) {
+  t.context.ad.groupExists('!!!NON-EXISTENT GROUP!!!', function (err, exists) {
     t.error(err)
     t.false(exists)
     t.end()

--- a/test/groupexistsPromised.test.js
+++ b/test/groupexistsPromised.test.js
@@ -22,7 +22,7 @@ tap.afterEach((done, t) => {
 })
 
 tap.test('should return true if the groupName (commonName) exists', t => {
-  return t.context.ad.groupExists(settings.sAMAccountName, settings.groupName.cn)
+  return t.context.ad.groupExists(settings.groupName.cn)
     .then((exists) => {
       t.true(exists)
     })
@@ -30,7 +30,7 @@ tap.test('should return true if the groupName (commonName) exists', t => {
 })
 
 tap.test('should return true if the groupName (distinguishedName) exists', t => {
-  return t.context.ad.groupExists(settings.sAMAccountName, settings.groupName.dn)
+  return t.context.ad.groupExists(settings.groupName.dn)
     .then((exists) => {
       t.true(exists)
     })
@@ -38,7 +38,7 @@ tap.test('should return true if the groupName (distinguishedName) exists', t => 
 })
 
 tap.test('should return false if the groupName doesn\'t exist', t => {
-  return t.context.ad.groupExists(settings.sAMAccountName, '!!!NON-EXISTENT GROUP!!!')
+  return t.context.ad.groupExists('!!!NON-EXISTENT GROUP!!!')
     .then((exists) => {
       t.false(exists)
     })


### PR DESCRIPTION
- Fixes #97 
    - I changed the tests to more closely match userExists tests, which don't pass in opts at all. If you want tests that test opts let me know, but I don't see what opts are even useful for groupExists. The tests do test against regression
- Also fixes rootDSE double emitting error events which seems to be caused by [this](https://github.com/ldapjs/node-ldapjs/pull/704) ldapjs change