### PR TITLE
GUID in the `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` string format.

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -139,7 +139,7 @@ const defaultEntryParser = function (entry, raw, callback) {
     entry.objectSid = utils.binarySidToStringSid(raw.objectSid)
   }
   if (Object.prototype.hasOwnProperty.call(raw, 'objectGUID')) {
-    entry.objectGUID = utils.binarySidToStringSid(raw.objectGUID)
+    entry.objectGUID = utils.binaryToGuidString(raw.objectGUID)
   }
   callback(entry)
 }

--- a/lib/components/utilities.js
+++ b/lib/components/utilities.js
@@ -428,7 +428,33 @@ function binarySidToStringSid (sid) {
   return parts.join('-')
 }
 
+/**
+ * Converts a binary GUID to a string representation.
+ *
+ * @param {Buffer} guid - Buffer containing 16 bytes of GUID.
+ * @returns {string} - GUID in the `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` string format.
+ * @throws {Error} - If the buffer length is not equal to 16 bytes.
+ */
+function binaryToGuidString(guid) {
+  if (guid.length !== 16) {
+    throw new Error("Invalid data length. Expected 16 bytes for GUID.");
+  }
+
+  // Use two-digit hex representation for each part
+  const parts = [];
+  parts.push(guid.readUInt32LE(0).toString(16).padStart(8, '0')); 
+  parts.push(guid.readUInt16LE(4).toString(16).padStart(4, '0'));
+  parts.push(guid.readUInt16LE(6).toString(16).padStart(4, '0'));
+  parts.push(guid.readUInt16BE(8).toString(16).padStart(4, '0')); 
+  parts.push(guid.slice(10).toString('hex'));
+
+  // Create GUID in the correct format
+  return parts.slice(0, 3).join('-') + '-' + parts.slice(3).join('-');
+}
+
+
 module.exports = {
+  binaryToGuidString,
   binarySidToStringSid,
   createClient,
   getCompoundFilter,


### PR DESCRIPTION
Description:

This pull request adds a new function binaryToGuidString that converts a binary GUID to a string representation.
The function uses the correct GUID format with hyphens (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).
It also checks the length of the GUID buffer and throws an error if it does not match 16 bytes.
Benefits:

This function simplifies working with GUIDs in code.
It provides a unified representation of GUIDs.
It increases code reliability by handling GUID length errors.

Please review this pull request and leave your feedback.

Thank you!