### PR TITLE
fix: Error Callback was already called when using getGroupMembershipForUser

### DIFF
--- a/lib/components/getGroupMembershipForDN.js
+++ b/lib/components/getGroupMembershipForDN.js
@@ -32,7 +32,15 @@ function GroupMembersForDN (opts, dn, callback, stack) {
  * @param {object} group An LDAP group entry to parse.
  * @param {function} acb The callback from the `async` library.
  */
-GroupMembersForDN.prototype.asyncIterator = function asyncIterator (group, acb) {
+GroupMembersForDN.prototype.asyncIterator = function asyncIterator (group, callback) {
+  let callbackCalled = false
+  const acb = (...args) => {
+    if(!callbackCalled) {
+      callbackCalled = true
+      callback(...args)
+    }
+  }
+
   if (this.stack.has(group.cn || group.dn)) {
     return acb()
   }


### PR DESCRIPTION
Hi, @jsumners!
This fixes the issue #106
Thank you.